### PR TITLE
Implement persistent brain states

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -178,6 +178,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  width: 33%;
 }
 
 .brain-icon {


### PR DESCRIPTION
## Summary
- keep brain status icons visible after thinking completes
- randomize thinking time per brain and show "gathering responses" when all done
- style brain wrappers to share the chat view evenly

## Testing
- `npm run format`
- `npm run lint` *(fails: Invalid option '--ext' due to eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_684ee58b24a0832d9f864ac286bafba5