### PR TITLE
Allow brain icons to persist as messages

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,3 +1,6 @@
+import { createRequire } from 'module'
+const require = createRequire(import.meta.url)
+
 export default [
   {
     files: ['**/*.ts', '**/*.tsx'],

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -1,51 +1,70 @@
 import { useState, type KeyboardEvent } from 'react'
 import BrainThinking from './BrainThinking'
 
-export interface Message {
-  id: number
-  text: string
-  sender: 'bot' | 'user'
-}
-
 const models = ['OpenAI', 'Claude', 'Gemini'] as const
-
 type ModelState = Record<(typeof models)[number], 'thinking' | 'done'>
 
 function randomDelay() {
   return Math.floor(Math.random() * 2000) + 1000 // 1-3 seconds
 }
 
+export type Message =
+  | {
+      id: number
+      type: 'text'
+      text: string
+      sender: 'bot' | 'user'
+    }
+  | {
+      id: number
+      type: 'brains'
+      states: ModelState
+    }
+
 export default function ChatView() {
   const [messages, setMessages] = useState<Message[]>([
-    { id: 1, text: 'Hello! Ask me anything.', sender: 'bot' },
+    { id: 1, type: 'text', text: 'Hello! Ask me anything.', sender: 'bot' },
   ])
   const [input, setInput] = useState('')
-  const [thinking, setThinking] = useState<ModelState | null>(null)
 
   const handleSend = () => {
     if (!input.trim()) return
     const prompt = input
     const userMessage: Message = {
       id: messages.length + 1,
+      type: 'text',
       text: prompt,
       sender: 'user',
     }
-    setMessages((m) => [...m, userMessage])
-    setInput('')
 
     const initial: ModelState = {
       OpenAI: 'thinking',
       Claude: 'thinking',
       Gemini: 'thinking',
     }
-    setThinking(initial)
+
+    const brainsId = Date.now()
+    const brainsMessage: Message = {
+      id: brainsId,
+      type: 'brains',
+      states: initial,
+    }
+
+    setMessages((m) => [...m, userMessage, brainsMessage])
+    setInput('')
 
     const thinkingPromises = models.map(
       (model) =>
         new Promise<void>((resolve) => {
           const delay = randomDelay()
           setTimeout(() => {
-            setThinking((t) => (t ? { ...t, [model]: 'done' } : t))
+            setMessages((msgs) =>
+              msgs.map((msg) =>
+                msg.id === brainsId && msg.type === 'brains'
+                  ? { ...msg, states: { ...msg.states, [model]: 'done' } }
+                  : msg,
+              ),
+            )
             resolve()
           }, delay)
         }),
@@ -54,6 +73,7 @@ export default function ChatView() {
     Promise.all(thinkingPromises).then(() => {
       const gather: Message = {
         id: Date.now(),
+        type: 'text',
         text: 'gathering responses',
         sender: 'bot',
       }
@@ -62,6 +82,7 @@ export default function ChatView() {
       setTimeout(() => {
         const botMessage: Message = {
           id: Date.now() + 1,
+          type: 'text',
           text: `Echo: ${prompt}`,
           sender: 'bot',
         }
@@ -78,17 +99,18 @@ export default function ChatView() {
     <div className="chat-container">
       <div className="chat-header">Welcome to Consensus AI</div>
       <div className="chat-messages">
-        {messages.map((m) => (
-          <div key={m.id} className={`message ${m.sender}`}>
-            {m.text}
-          </div>
-        ))}
-        {thinking && (
-          <div className="thinking-container">
-            {models.map((m) => (
-              <BrainThinking key={m} label={m} state={thinking[m]} />
-            ))}
-          </div>
+        {messages.map((m) =>
+          m.type === 'text' ? (
+            <div key={m.id} className={`message ${m.sender}`}>
+              {m.text}
+            </div>
+          ) : (
+            <div key={m.id} className="thinking-container">
+              {models.map((model) => (
+                <BrainThinking key={model} label={model} state={m.states[model]} />
+              ))}
+            </div>
+          ),
         )}
       </div>
       <div className="chat-input">


### PR DESCRIPTION
## Summary
- treat brain states as a new `brains` message type
- insert brain messages directly into the chat history
- update each brain message as its model finishes
- tweak eslint config so `require` works in ESM

## Testing
- `npm run lint` *(fails: invalid option `--ext`)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684ee79dc490832da264e3d799a94359